### PR TITLE
Security: Stored XSS via unsanitized rich HTML rendering

### DIFF
--- a/src/materials/base/RichText/index.tsx
+++ b/src/materials/base/RichText/index.tsx
@@ -7,6 +7,27 @@ interface IProps extends IButtonConfig {
   isTpl: boolean;
 }
 
+const sanitizeHtml = (html = "") => {
+  if (typeof document === "undefined") {
+    return html;
+  }
+  const div = document.createElement("div");
+  div.innerHTML = html;
+  div
+    .querySelectorAll("script,iframe,object,embed,link,style,meta")
+    .forEach((node) => node.remove());
+  div.querySelectorAll("*").forEach((node) => {
+    Array.from(node.attributes).forEach((attr) => {
+      const name = attr.name.toLowerCase();
+      const value = attr.value.trim().toLowerCase();
+      if (name.indexOf("on") === 0 || value.indexOf("javascript:") === 0) {
+        node.removeAttribute(attr.name);
+      }
+    });
+  });
+  return div.innerHTML;
+};
+
 const XButton = memo((props: IProps) => {
   const { isTpl, borderColor, borderWidth, round, padding, content } = props;
 
@@ -23,7 +44,7 @@ const XButton = memo((props: IProps) => {
         padding: padding + "px"
       }}
     >
-      <div dangerouslySetInnerHTML={{ __html: content }}></div>
+      <div dangerouslySetInnerHTML={{ __html: sanitizeHtml(content) }}></div>
     </div>
   );
 });

--- a/src/materials/shop/ZhuanLan/index.tsx
+++ b/src/materials/shop/ZhuanLan/index.tsx
@@ -7,6 +7,27 @@ interface IProps extends IZLConfig {
   isTpl?: boolean;
 }
 
+const sanitizeHtml = (html = "") => {
+  if (typeof document === "undefined") {
+    return html;
+  }
+  const div = document.createElement("div");
+  div.innerHTML = html;
+  div
+    .querySelectorAll("script,iframe,object,embed,link,style,meta")
+    .forEach((node) => node.remove());
+  div.querySelectorAll("*").forEach((node) => {
+    Array.from(node.attributes).forEach((attr) => {
+      const name = attr.name.toLowerCase();
+      const value = attr.value.trim().toLowerCase();
+      if (name.indexOf("on") === 0 || value.indexOf("javascript:") === 0) {
+        node.removeAttribute(attr.name);
+      }
+    });
+  });
+  return div.innerHTML;
+};
+
 const ZL = memo((props: IProps) => {
   const {
     title,
@@ -77,7 +98,7 @@ const ZL = memo((props: IProps) => {
       </div>
       <div
         className={styles.content}
-        dangerouslySetInnerHTML={{ __html: content }}
+        dangerouslySetInnerHTML={{ __html: sanitizeHtml(content) }}
       ></div>
     </div>
   );


### PR DESCRIPTION
## Problem

User-controlled `content` is rendered with `dangerouslySetInnerHTML` without sanitization. An attacker can inject scripts/event handlers (for example via stored page content) and execute arbitrary JavaScript in visitors' browsers.

**Severity**: `high`
**File**: `src/materials/base/RichText/index.tsx`

## Solution

Sanitize HTML before rendering (e.g., DOMPurify with a strict allowlist) and strip dangerous tags/attributes (`script`, `on*`, `javascript:` URLs). Prefer rendering structured rich-text data instead of raw HTML where possible.

## Changes

- `src/materials/base/RichText/index.tsx` (modified)
- `src/materials/shop/ZhuanLan/index.tsx` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
