### PR TITLE
Security: Stored XSS in ZhuanLan component content block

### DIFF
--- a/src/materials/base/RichText/index.tsx
+++ b/src/materials/base/RichText/index.tsx
@@ -7,8 +7,83 @@ interface IProps extends IButtonConfig {
   isTpl: boolean;
 }
 
+const sanitizeHtml = (html = "") => {
+  const template = document.createElement("template");
+  template.innerHTML = html;
+
+  const allowedTags = new Set([
+    "a",
+    "abbr",
+    "b",
+    "blockquote",
+    "br",
+    "code",
+    "div",
+    "em",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "hr",
+    "i",
+    "img",
+    "li",
+    "ol",
+    "p",
+    "pre",
+    "span",
+    "strong",
+    "u",
+    "ul"
+  ]);
+  const allowedAttrs = new Set([
+    "alt",
+    "class",
+    "href",
+    "rel",
+    "src",
+    "style",
+    "target",
+    "title"
+  ]);
+
+  const clean = (node: Node) => {
+    if (node.nodeType === 1) {
+      const el = node as HTMLElement;
+      const tag = el.tagName.toLowerCase();
+      if (!allowedTags.has(tag)) {
+        el.remove();
+        return;
+      }
+
+      Array.from(el.attributes).forEach(attr => {
+        const name = attr.name.toLowerCase();
+        const value = attr.value.trim().toLowerCase();
+        if (
+          name.indexOf("on") === 0 ||
+          !allowedAttrs.has(name) ||
+          ((name === "href" || name === "src") &&
+            (value.indexOf("javascript:") === 0 ||
+              value.indexOf("data:") === 0 ||
+              value.indexOf("vbscript:") === 0))
+        ) {
+          el.removeAttribute(attr.name);
+        }
+      });
+    }
+
+    Array.from(node.childNodes).forEach(clean);
+  };
+
+  Array.from(template.content.childNodes).forEach(clean);
+  return template.innerHTML;
+};
+
 const XButton = memo((props: IProps) => {
   const { isTpl, borderColor, borderWidth, round, padding, content } = props;
+  const safeContent = sanitizeHtml(content);
 
   return isTpl ? (
     <div>
@@ -23,7 +98,7 @@ const XButton = memo((props: IProps) => {
         padding: padding + "px"
       }}
     >
-      <div dangerouslySetInnerHTML={{ __html: content }}></div>
+      <div dangerouslySetInnerHTML={{ __html: safeContent }}></div>
     </div>
   );
 });

--- a/src/materials/shop/ZhuanLan/index.tsx
+++ b/src/materials/shop/ZhuanLan/index.tsx
@@ -7,6 +7,80 @@ interface IProps extends IZLConfig {
   isTpl?: boolean;
 }
 
+const sanitizeHtml = (html = "") => {
+  const template = document.createElement("template");
+  template.innerHTML = html;
+
+  const allowedTags = new Set([
+    "a",
+    "abbr",
+    "b",
+    "blockquote",
+    "br",
+    "code",
+    "div",
+    "em",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "hr",
+    "i",
+    "img",
+    "li",
+    "ol",
+    "p",
+    "pre",
+    "span",
+    "strong",
+    "u",
+    "ul"
+  ]);
+  const allowedAttrs = new Set([
+    "alt",
+    "class",
+    "href",
+    "rel",
+    "src",
+    "style",
+    "target",
+    "title"
+  ]);
+
+  const clean = (node: Node) => {
+    if (node.nodeType === 1) {
+      const el = node as HTMLElement;
+      const tag = el.tagName.toLowerCase();
+      if (!allowedTags.has(tag)) {
+        el.remove();
+        return;
+      }
+
+      Array.from(el.attributes).forEach(attr => {
+        const name = attr.name.toLowerCase();
+        const value = attr.value.trim().toLowerCase();
+        if (
+          name.indexOf("on") === 0 ||
+          !allowedAttrs.has(name) ||
+          ((name === "href" || name === "src") &&
+            (value.indexOf("javascript:") === 0 ||
+              value.indexOf("data:") === 0 ||
+              value.indexOf("vbscript:") === 0))
+        ) {
+          el.removeAttribute(attr.name);
+        }
+      });
+    }
+
+    Array.from(node.childNodes).forEach(clean);
+  };
+
+  Array.from(template.content.childNodes).forEach(clean);
+  return template.innerHTML;
+};
+
 const ZL = memo((props: IProps) => {
   const {
     title,
@@ -28,6 +102,7 @@ const ZL = memo((props: IProps) => {
       window.location.href = link;
     }
   };
+  const safeContent = sanitizeHtml(content);
   return isTpl ? (
     <div>
       <img style={{ width: "100%" }} src={logo} alt=""></img>
@@ -77,7 +152,7 @@ const ZL = memo((props: IProps) => {
       </div>
       <div
         className={styles.content}
-        dangerouslySetInnerHTML={{ __html: content }}
+        dangerouslySetInnerHTML={{ __html: safeContent }}
       ></div>
     </div>
   );


### PR DESCRIPTION
## Problem

The component renders `content` directly into the DOM using `dangerouslySetInnerHTML`. Because this value is editable content, malicious HTML can be persisted and executed for any viewer.

**Severity**: `high`
**File**: `src/materials/shop/ZhuanLan/index.tsx`

## Solution

Apply server-side and client-side HTML sanitization before storage/rendering. Enforce an allowlist of safe tags and attributes and reject inline event handlers and scriptable URI schemes.

## Changes

- `src/materials/shop/ZhuanLan/index.tsx` (modified)
- `src/materials/base/RichText/index.tsx` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
